### PR TITLE
Removed depracated functions in mongo 3.4, added Oplog lag and oplog sync metrics

### DIFF
--- a/Templates/Template_MongoDB.xml
+++ b/Templates/Template_MongoDB.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
     <version>3.2</version>
-    <date>2017-08-11T10:47:57Z</date>
+    <date>2017-08-11T11:49:17Z</date>
     <groups>
         <group>
             <name>Templates</name>
@@ -376,9 +376,9 @@
                     <key>mongodb.fsync-locked</key>
                     <delay>0</delay>
                     <history>28</history>
-                    <trends>0</trends>
+                    <trends>365</trends>
                     <status>0</status>
-                    <value_type>4</value_type>
+                    <value_type>3</value_type>
                     <allowed_hosts/>
                     <units/>
                     <delta>0</delta>
@@ -393,7 +393,7 @@
                     <delay_flex/>
                     <params/>
                     <ipmi_sensor/>
-                    <data_type>0</data_type>
+                    <data_type>3</data_type>
                     <authtype>0</authtype>
                     <username/>
                     <password/>
@@ -720,9 +720,9 @@
                     <key>mongodb.hidden</key>
                     <delay>0</delay>
                     <history>28</history>
-                    <trends>0</trends>
+                    <trends>365</trends>
                     <status>0</status>
-                    <value_type>4</value_type>
+                    <value_type>3</value_type>
                     <allowed_hosts/>
                     <units/>
                     <delta>0</delta>
@@ -737,7 +737,7 @@
                     <delay_flex/>
                     <params/>
                     <ipmi_sensor/>
-                    <data_type>0</data_type>
+                    <data_type>3</data_type>
                     <authtype>0</authtype>
                     <username/>
                     <password/>
@@ -1713,7 +1713,7 @@ The amount of mapped memory, in megabytes (MB), including the memory used for jo
                     <multiplier>0</multiplier>
                     <snmp_oid/>
                     <key>mongodb.zabbix.sender</key>
-                    <delay>300</delay>
+                    <delay>30</delay>
                     <history>28</history>
                     <trends>365</trends>
                     <status>0</status>
@@ -2811,8 +2811,8 @@ Only present when using the mmapv1 storage engine.</description>
     </templates>
     <triggers>
         <trigger>
-            <expression>{Template MongoDB:mongodb.fsync-locked.str(&quot;True&quot;)}=1 &#13;
-and {Template MongoDB:mongodb.hidden.str(&quot;True&quot;)}=1 &#13;
+            <expression>{Template MongoDB:mongodb.fsync-locked.last()}=1 &#13;
+and {Template MongoDB:mongodb.hidden.last()}=1 &#13;
 and {Template MongoDB:mongodb.priority.last()}=0</expression>
             <recovery_mode>0</recovery_mode>
             <recovery_expression/>
@@ -2829,8 +2829,8 @@ and {Template MongoDB:mongodb.priority.last()}=0</expression>
             <tags/>
         </trigger>
         <trigger>
-            <expression>{Template MongoDB:mongodb.fsync-locked.str(&quot;True&quot;)}=1 &#13;
-and {Template MongoDB:mongodb.hidden.str(&quot;True&quot;)}=1 &#13;
+            <expression>{Template MongoDB:mongodb.fsync-locked.last()}=1 &#13;
+and {Template MongoDB:mongodb.hidden.last()}=1 &#13;
 and {Template MongoDB:mongodb.priority.last()}=1</expression>
             <recovery_mode>0</recovery_mode>
             <recovery_expression/>
@@ -2847,8 +2847,8 @@ and {Template MongoDB:mongodb.priority.last()}=1</expression>
             <tags/>
         </trigger>
         <trigger>
-            <expression>{Template MongoDB:mongodb.fsync-locked.str(&quot;True&quot;)}=1 &#13;
-and {Template MongoDB:mongodb.hidden.str(&quot;False&quot;)}=1 &#13;
+            <expression>{Template MongoDB:mongodb.fsync-locked.last()}=1 &#13;
+and {Template MongoDB:mongodb.hidden.last()}=0&#13;
 and {Template MongoDB:mongodb.priority.last()}=0</expression>
             <recovery_mode>0</recovery_mode>
             <recovery_expression/>
@@ -2865,8 +2865,8 @@ and {Template MongoDB:mongodb.priority.last()}=0</expression>
             <tags/>
         </trigger>
         <trigger>
-            <expression>{Template MongoDB:mongodb.fsync-locked.str(&quot;True&quot;)}=1 &#13;
-and {Template MongoDB:mongodb.hidden.str(&quot;False&quot;)}=1 &#13;
+            <expression>{Template MongoDB:mongodb.fsync-locked.last()}=1 &#13;
+and {Template MongoDB:mongodb.hidden.last()}=0&#13;
 and {Template MongoDB:mongodb.priority.last()}=1</expression>
             <recovery_mode>0</recovery_mode>
             <recovery_expression/>
@@ -2979,8 +2979,8 @@ and {Template MongoDB:mongodb.priority.last()}=1</expression>
             <tags/>
         </trigger>
         <trigger>
-            <expression>{Template MongoDB:mongodb.fsync-locked.str(&quot;False&quot;)}=1 &#13;
-and {Template MongoDB:mongodb.hidden.str(&quot;True&quot;)}=1 &#13;
+            <expression>{Template MongoDB:mongodb.fsync-locked.last()}=0&#13;
+and {Template MongoDB:mongodb.hidden.last()}=1 &#13;
 and {Template MongoDB:mongodb.priority.last()}=0</expression>
             <recovery_mode>0</recovery_mode>
             <recovery_expression/>
@@ -2997,8 +2997,8 @@ and {Template MongoDB:mongodb.priority.last()}=0</expression>
             <tags/>
         </trigger>
         <trigger>
-            <expression>{Template MongoDB:mongodb.fsync-locked.str(&quot;False&quot;)}=1 &#13;
-and {Template MongoDB:mongodb.hidden.str(&quot;True&quot;)}=1 &#13;
+            <expression>{Template MongoDB:mongodb.fsync-locked.last()}=0&#13;
+and {Template MongoDB:mongodb.hidden.last()}=1 &#13;
 and {Template MongoDB:mongodb.priority.last()}=1</expression>
             <recovery_mode>0</recovery_mode>
             <recovery_expression/>
@@ -3015,8 +3015,8 @@ and {Template MongoDB:mongodb.priority.last()}=1</expression>
             <tags/>
         </trigger>
         <trigger>
-            <expression>{Template MongoDB:mongodb.fsync-locked.str(&quot;False&quot;)}=1 &#13;
-and {Template MongoDB:mongodb.hidden.str(&quot;False&quot;)}=1 &#13;
+            <expression>{Template MongoDB:mongodb.fsync-locked.last()}=0 &#13;
+and {Template MongoDB:mongodb.hidden.last()}=0&#13;
 and {Template MongoDB:mongodb.priority.last()}=0</expression>
             <recovery_mode>0</recovery_mode>
             <recovery_expression/>

--- a/Templates/Template_MongoDB.xml
+++ b/Templates/Template_MongoDB.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
-    <version>3.0</version>
-    <date>2017-05-06T12:40:48Z</date>
+    <version>3.2</version>
+    <date>2017-08-11T09:10:15Z</date>
     <groups>
         <group>
             <name>Templates</name>
@@ -1449,6 +1449,92 @@ The amount of mapped memory, in megabytes (MB), including the memory used for jo
                     <logtimefmt/>
                 </item>
                 <item>
+                    <name>MongoDB::OplogLength</name>
+                    <type>2</type>
+                    <snmp_community/>
+                    <multiplier>0</multiplier>
+                    <snmp_oid/>
+                    <key>mongodb.oplog</key>
+                    <delay>0</delay>
+                    <history>28</history>
+                    <trends>365</trends>
+                    <status>0</status>
+                    <value_type>0</value_type>
+                    <allowed_hosts/>
+                    <units>s</units>
+                    <delta>0</delta>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <formula>1</formula>
+                    <delay_flex/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <data_type>0</data_type>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description/>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>MongoDB</name>
+                        </application>
+                    </applications>
+                    <valuemap/>
+                    <logtimefmt/>
+                </item>
+                <item>
+                    <name>MongoDB::OplogSync</name>
+                    <type>2</type>
+                    <snmp_community/>
+                    <multiplier>0</multiplier>
+                    <snmp_oid/>
+                    <key>mongodb.oplog-sync</key>
+                    <delay>0</delay>
+                    <history>28</history>
+                    <trends>365</trends>
+                    <status>0</status>
+                    <value_type>0</value_type>
+                    <allowed_hosts/>
+                    <units>s</units>
+                    <delta>0</delta>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <formula>1</formula>
+                    <delay_flex/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <data_type>0</data_type>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description/>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>MongoDB</name>
+                        </application>
+                    </applications>
+                    <valuemap/>
+                    <logtimefmt/>
+                </item>
+                <item>
                     <name>MongoDB::page fault rate</name>
                     <type>2</type>
                     <snmp_community/>
@@ -2235,13 +2321,19 @@ Only present when using the mmapv1 storage engine.</description>
                     <trigger_prototypes>
                         <trigger_prototype>
                             <expression>{Template MongoDB:mongodb.stats.ok[{#MONGODBNAME}].count(#3,0)}=3</expression>
+                            <recovery_mode>0</recovery_mode>
+                            <recovery_expression/>
                             <name>MongoDB::{#MONGODBNAME} is not OK</name>
+                            <correlation_mode>0</correlation_mode>
+                            <correlation_tag/>
                             <url/>
                             <status>0</status>
                             <priority>3</priority>
                             <description/>
                             <type>0</type>
+                            <manual_close>0</manual_close>
                             <dependencies/>
+                            <tags/>
                         </trigger_prototype>
                     </trigger_prototypes>
                     <graph_prototypes>
@@ -2449,6 +2541,7 @@ Only present when using the mmapv1 storage engine.</description>
                     <host_prototypes/>
                 </discovery_rule>
             </discovery_rules>
+            <httptests/>
             <macros>
                 <macro>
                     <macro>{$PAGE_FAULT_TH_WARN}</macro>
@@ -2740,34 +2833,116 @@ Only present when using the mmapv1 storage engine.</description>
     </templates>
     <triggers>
         <trigger>
-            <expression>{Template MongoDB:proc.num[mongod].count(#3,0)}=3</expression>
-            <name>MongoDB process is not running on {HOST.NAME}</name>
+            <expression>{Template MongoDB:mongodb.oplog.last()}&lt;259200</expression>
+            <recovery_mode>1</recovery_mode>
+            <recovery_expression>{Template MongoDB:mongodb.oplog.last()}&gt;259320</recovery_expression>
+            <name>MongoDB Oplog length 3 days on {HOST.NAME}</name>
+            <correlation_mode>0</correlation_mode>
+            <correlation_tag/>
             <url/>
             <status>0</status>
             <priority>4</priority>
             <description/>
             <type>0</type>
+            <manual_close>0</manual_close>
             <dependencies/>
+            <tags/>
         </trigger>
         <trigger>
-            <expression>{Template MongoDB:mongodb.okstatus.count(#3,0)}=3</expression>
-            <name>MongoDB server status is not OK</name>
-            <url/>
-            <status>0</status>
-            <priority>3</priority>
-            <description/>
-            <type>0</type>
-            <dependencies/>
-        </trigger>
-        <trigger>
-            <expression>{Template MongoDB:mongodb.page.faults.min(#3)}&gt;{$PAGE_FAULT_TH_WARN}</expression>
-            <name>Page faults detected on {HOST.NAME} (LV={ITEM.VALUE})</name>
+            <expression>{Template MongoDB:mongodb.oplog.last()}&lt;604800</expression>
+            <recovery_mode>1</recovery_mode>
+            <recovery_expression>{Template MongoDB:mongodb.oplog.last()}&gt;604920</recovery_expression>
+            <name>MongoDB Oplog length 7 days on {HOST.NAME}</name>
+            <correlation_mode>0</correlation_mode>
+            <correlation_tag/>
             <url/>
             <status>0</status>
             <priority>2</priority>
             <description/>
             <type>0</type>
+            <manual_close>0</manual_close>
             <dependencies/>
+            <tags/>
+        </trigger>
+        <trigger>
+            <expression>{Template MongoDB:mongodb.oplog-sync.last()}=60</expression>
+            <recovery_mode>1</recovery_mode>
+            <recovery_expression>{Template MongoDB:mongodb.oplog-sync.last()}&lt;30</recovery_expression>
+            <name>MongoDB Oplog Sync 1 minute on {HOST.NAME}</name>
+            <correlation_mode>0</correlation_mode>
+            <correlation_tag/>
+            <url/>
+            <status>0</status>
+            <priority>2</priority>
+            <description/>
+            <type>0</type>
+            <manual_close>0</manual_close>
+            <dependencies/>
+            <tags/>
+        </trigger>
+        <trigger>
+            <expression>{Template MongoDB:mongodb.oplog-sync.last()}=300</expression>
+            <recovery_mode>1</recovery_mode>
+            <recovery_expression>{Template MongoDB:mongodb.oplog-sync.last()}&lt;240</recovery_expression>
+            <name>MongoDB Oplog Sync 5 minute on {HOST.NAME}</name>
+            <correlation_mode>0</correlation_mode>
+            <correlation_tag/>
+            <url/>
+            <status>0</status>
+            <priority>4</priority>
+            <description/>
+            <type>0</type>
+            <manual_close>0</manual_close>
+            <dependencies/>
+            <tags/>
+        </trigger>
+        <trigger>
+            <expression>{Template MongoDB:proc.num[mongod].count(#3,0)}=3</expression>
+            <recovery_mode>0</recovery_mode>
+            <recovery_expression/>
+            <name>MongoDB process is not running on {HOST.NAME}</name>
+            <correlation_mode>0</correlation_mode>
+            <correlation_tag/>
+            <url/>
+            <status>0</status>
+            <priority>4</priority>
+            <description/>
+            <type>0</type>
+            <manual_close>0</manual_close>
+            <dependencies/>
+            <tags/>
+        </trigger>
+        <trigger>
+            <expression>{Template MongoDB:mongodb.okstatus.count(#3,0)}=3</expression>
+            <recovery_mode>0</recovery_mode>
+            <recovery_expression/>
+            <name>MongoDB server status is not OK</name>
+            <correlation_mode>0</correlation_mode>
+            <correlation_tag/>
+            <url/>
+            <status>0</status>
+            <priority>3</priority>
+            <description/>
+            <type>0</type>
+            <manual_close>0</manual_close>
+            <dependencies/>
+            <tags/>
+        </trigger>
+        <trigger>
+            <expression>{Template MongoDB:mongodb.page.faults.min(#3)}&gt;{$PAGE_FAULT_TH_WARN}</expression>
+            <recovery_mode>0</recovery_mode>
+            <recovery_expression/>
+            <name>Page faults detected on {HOST.NAME} (LV={ITEM.VALUE})</name>
+            <correlation_mode>0</correlation_mode>
+            <correlation_tag/>
+            <url/>
+            <status>0</status>
+            <priority>2</priority>
+            <description/>
+            <type>0</type>
+            <manual_close>0</manual_close>
+            <dependencies/>
+            <tags/>
         </trigger>
     </triggers>
     <graphs>
@@ -3275,6 +3450,70 @@ Only present when using the mmapv1 storage engine.</description>
                     <item>
                         <host>Template MongoDB</host>
                         <key>mongodb.operation.update</key>
+                    </item>
+                </graph_item>
+            </graph_items>
+        </graph>
+        <graph>
+            <name>MongoDB::OplogLength</name>
+            <width>900</width>
+            <height>200</height>
+            <yaxismin>0.0000</yaxismin>
+            <yaxismax>100.0000</yaxismax>
+            <show_work_period>1</show_work_period>
+            <show_triggers>1</show_triggers>
+            <type>0</type>
+            <show_legend>1</show_legend>
+            <show_3d>0</show_3d>
+            <percent_left>0.0000</percent_left>
+            <percent_right>0.0000</percent_right>
+            <ymin_type_1>0</ymin_type_1>
+            <ymax_type_1>0</ymax_type_1>
+            <ymin_item_1>0</ymin_item_1>
+            <ymax_item_1>0</ymax_item_1>
+            <graph_items>
+                <graph_item>
+                    <sortorder>0</sortorder>
+                    <drawtype>0</drawtype>
+                    <color>1A7C11</color>
+                    <yaxisside>0</yaxisside>
+                    <calc_fnc>2</calc_fnc>
+                    <type>0</type>
+                    <item>
+                        <host>Template MongoDB</host>
+                        <key>mongodb.oplog</key>
+                    </item>
+                </graph_item>
+            </graph_items>
+        </graph>
+        <graph>
+            <name>MongoDB::OplogSync</name>
+            <width>900</width>
+            <height>200</height>
+            <yaxismin>0.0000</yaxismin>
+            <yaxismax>100.0000</yaxismax>
+            <show_work_period>1</show_work_period>
+            <show_triggers>1</show_triggers>
+            <type>0</type>
+            <show_legend>1</show_legend>
+            <show_3d>0</show_3d>
+            <percent_left>0.0000</percent_left>
+            <percent_right>0.0000</percent_right>
+            <ymin_type_1>0</ymin_type_1>
+            <ymax_type_1>0</ymax_type_1>
+            <ymin_item_1>0</ymin_item_1>
+            <ymax_item_1>0</ymax_item_1>
+            <graph_items>
+                <graph_item>
+                    <sortorder>0</sortorder>
+                    <drawtype>0</drawtype>
+                    <color>1A7C11</color>
+                    <yaxisside>0</yaxisside>
+                    <calc_fnc>2</calc_fnc>
+                    <type>0</type>
+                    <item>
+                        <host>Template MongoDB</host>
+                        <key>mongodb.oplog-sync</key>
                     </item>
                 </graph_item>
             </graph_items>

--- a/Templates/Template_MongoDB.xml
+++ b/Templates/Template_MongoDB.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
     <version>3.2</version>
-    <date>2017-08-11T11:49:17Z</date>
+    <date>2017-08-14T15:50:26Z</date>
     <groups>
         <group>
             <name>Templates</name>
@@ -358,6 +358,49 @@
                     <privatekey/>
                     <port/>
                     <description>Count of all incoming connections created to the server. This number includes connections that have since closed.</description>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>MongoDB</name>
+                        </application>
+                    </applications>
+                    <valuemap/>
+                    <logtimefmt/>
+                </item>
+                <item>
+                    <name>MongoDB::Wired Tiger Dirty Cache</name>
+                    <type>2</type>
+                    <snmp_community/>
+                    <multiplier>0</multiplier>
+                    <snmp_oid/>
+                    <key>mongodb.dirty-cache</key>
+                    <delay>0</delay>
+                    <history>28</history>
+                    <trends>365</trends>
+                    <status>0</status>
+                    <value_type>3</value_type>
+                    <allowed_hosts/>
+                    <units>B</units>
+                    <delta>0</delta>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <formula>1</formula>
+                    <delay_flex/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <data_type>0</data_type>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description/>
                     <inventory_link>0</inventory_link>
                     <applications>
                         <application>
@@ -800,49 +843,6 @@
                     <logtimefmt/>
                 </item>
                 <item>
-                    <name>MongoDB::memory::mapped</name>
-                    <type>2</type>
-                    <snmp_community/>
-                    <multiplier>1</multiplier>
-                    <snmp_oid/>
-                    <key>mongodb.memory.mapped</key>
-                    <delay>0</delay>
-                    <history>28</history>
-                    <trends>365</trends>
-                    <status>0</status>
-                    <value_type>3</value_type>
-                    <allowed_hosts/>
-                    <units>B</units>
-                    <delta>0</delta>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <formula>1048576</formula>
-                    <delay_flex/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <data_type>0</data_type>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <description/>
-                    <inventory_link>0</inventory_link>
-                    <applications>
-                        <application>
-                            <name>MongoDB</name>
-                        </application>
-                    </applications>
-                    <valuemap/>
-                    <logtimefmt/>
-                </item>
-                <item>
                     <name>MongoDB::memory::mappedWithJournal</name>
                     <type>2</type>
                     <snmp_community/>
@@ -878,49 +878,6 @@
                     <description>Only for the MMAPv1 storage engine.&#13;
 &#13;
 The amount of mapped memory, in megabytes (MB), including the memory used for journaling. This value will always be twice the value of mem.mapped. This field is only included if journaling is enabled.</description>
-                    <inventory_link>0</inventory_link>
-                    <applications>
-                        <application>
-                            <name>MongoDB</name>
-                        </application>
-                    </applications>
-                    <valuemap/>
-                    <logtimefmt/>
-                </item>
-                <item>
-                    <name>MongoDB::memory::resident</name>
-                    <type>2</type>
-                    <snmp_community/>
-                    <multiplier>1</multiplier>
-                    <snmp_oid/>
-                    <key>mongodb.memory.resident</key>
-                    <delay>0</delay>
-                    <history>28</history>
-                    <trends>365</trends>
-                    <status>0</status>
-                    <value_type>3</value_type>
-                    <allowed_hosts/>
-                    <units>B</units>
-                    <delta>0</delta>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <formula>1048576</formula>
-                    <delay_flex/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <data_type>0</data_type>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <description/>
                     <inventory_link>0</inventory_link>
                     <applications>
                         <application>
@@ -1621,6 +1578,49 @@ The amount of mapped memory, in megabytes (MB), including the memory used for jo
                     <logtimefmt/>
                 </item>
                 <item>
+                    <name>MongoDB::Wired Tiger Total Cache</name>
+                    <type>2</type>
+                    <snmp_community/>
+                    <multiplier>0</multiplier>
+                    <snmp_oid/>
+                    <key>mongodb.total-cache</key>
+                    <delay>0</delay>
+                    <history>28</history>
+                    <trends>365</trends>
+                    <status>0</status>
+                    <value_type>3</value_type>
+                    <allowed_hosts/>
+                    <units>B</units>
+                    <delta>0</delta>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <formula>1</formula>
+                    <delay_flex/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <data_type>0</data_type>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description/>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>MongoDB</name>
+                        </application>
+                    </applications>
+                    <valuemap/>
+                    <logtimefmt/>
+                </item>
+                <item>
                     <name>MongoDB::uptime</name>
                     <type>2</type>
                     <snmp_community/>
@@ -1645,6 +1645,92 @@ The amount of mapped memory, in megabytes (MB), including the memory used for jo
                     <formula>1</formula>
                     <delay_flex/>
                     <params/>
+                    <ipmi_sensor/>
+                    <data_type>0</data_type>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description/>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>MongoDB</name>
+                        </application>
+                    </applications>
+                    <valuemap/>
+                    <logtimefmt/>
+                </item>
+                <item>
+                    <name>MongoDB::Wired Tiger Used Cache</name>
+                    <type>2</type>
+                    <snmp_community/>
+                    <multiplier>0</multiplier>
+                    <snmp_oid/>
+                    <key>mongodb.used-cache</key>
+                    <delay>0</delay>
+                    <history>28</history>
+                    <trends>365</trends>
+                    <status>0</status>
+                    <value_type>3</value_type>
+                    <allowed_hosts/>
+                    <units>B</units>
+                    <delta>0</delta>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <formula>1</formula>
+                    <delay_flex/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <data_type>0</data_type>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description/>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>MongoDB</name>
+                        </application>
+                    </applications>
+                    <valuemap/>
+                    <logtimefmt/>
+                </item>
+                <item>
+                    <name>MongoDB::Wired Tiger Used Cache %</name>
+                    <type>15</type>
+                    <snmp_community/>
+                    <multiplier>0</multiplier>
+                    <snmp_oid/>
+                    <key>mongodb.used-cache-p</key>
+                    <delay>30</delay>
+                    <history>90</history>
+                    <trends>365</trends>
+                    <status>0</status>
+                    <value_type>3</value_type>
+                    <allowed_hosts/>
+                    <units>%</units>
+                    <delta>0</delta>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <formula>1</formula>
+                    <delay_flex/>
+                    <params>(100 * last(mongodb.used-cache) / last(mongodb.total-cache))</params>
                     <ipmi_sensor/>
                     <data_type>0</data_type>
                     <authtype>0</authtype>
@@ -2899,7 +2985,7 @@ and {Template MongoDB:mongodb.priority.last()}=1</expression>
             <tags/>
         </trigger>
         <trigger>
-            <expression>{Template MongoDB:mongodb.oplog.last()}&lt;604800</expression>
+            <expression>{Template MongoDB:mongodb.oplog.last()}&lt;604800 and not {Template MongoDB:mongodb.oplog.last()}&lt;259200</expression>
             <recovery_mode>1</recovery_mode>
             <recovery_expression>{Template MongoDB:mongodb.oplog.last()}&gt;604920</recovery_expression>
             <name>MongoDB Oplog length 7 days on {HOST.NAME}</name>
@@ -2915,7 +3001,7 @@ and {Template MongoDB:mongodb.priority.last()}=1</expression>
             <tags/>
         </trigger>
         <trigger>
-            <expression>{Template MongoDB:mongodb.oplog-sync.last()}=60</expression>
+            <expression>{Template MongoDB:mongodb.oplog-sync.last()}&gt;=60 and not {Template MongoDB:mongodb.oplog-sync.last()}&gt;=300</expression>
             <recovery_mode>1</recovery_mode>
             <recovery_expression>{Template MongoDB:mongodb.oplog-sync.last()}&lt;30</recovery_expression>
             <name>MongoDB Oplog Sync 1 minute on {HOST.NAME}</name>
@@ -2931,7 +3017,7 @@ and {Template MongoDB:mongodb.priority.last()}=1</expression>
             <tags/>
         </trigger>
         <trigger>
-            <expression>{Template MongoDB:mongodb.oplog-sync.last()}=300</expression>
+            <expression>{Template MongoDB:mongodb.oplog-sync.last()}&gt;=300</expression>
             <recovery_mode>1</recovery_mode>
             <recovery_expression>{Template MongoDB:mongodb.oplog-sync.last()}&lt;240</recovery_expression>
             <name>MongoDB Oplog Sync 5 minute on {HOST.NAME}</name>
@@ -2972,6 +3058,38 @@ and {Template MongoDB:mongodb.priority.last()}=1</expression>
             <url/>
             <status>0</status>
             <priority>3</priority>
+            <description/>
+            <type>0</type>
+            <manual_close>0</manual_close>
+            <dependencies/>
+            <tags/>
+        </trigger>
+        <trigger>
+            <expression>{Template MongoDB:mongodb.used-cache-p.last()}&gt;=90 and {Template MongoDB:mongodb.used-cache-p.last()}&lt;95</expression>
+            <recovery_mode>0</recovery_mode>
+            <recovery_expression/>
+            <name>MongoDB Wired Tiger Used cache 90% on  {HOST.NAME}</name>
+            <correlation_mode>0</correlation_mode>
+            <correlation_tag/>
+            <url/>
+            <status>0</status>
+            <priority>2</priority>
+            <description/>
+            <type>0</type>
+            <manual_close>0</manual_close>
+            <dependencies/>
+            <tags/>
+        </trigger>
+        <trigger>
+            <expression>{Template MongoDB:mongodb.used-cache-p.last()}&gt;=95</expression>
+            <recovery_mode>0</recovery_mode>
+            <recovery_expression/>
+            <name>MongoDB Wired Tiger Used cache 95% on  {HOST.NAME}</name>
+            <correlation_mode>0</correlation_mode>
+            <correlation_tag/>
+            <url/>
+            <status>0</status>
+            <priority>4</priority>
             <description/>
             <type>0</type>
             <manual_close>0</manual_close>
@@ -3337,19 +3455,7 @@ and {Template MongoDB:mongodb.priority.last()}=0</expression>
                     <type>0</type>
                     <item>
                         <host>Template MongoDB</host>
-                        <key>mongodb.memory.mapped</key>
-                    </item>
-                </graph_item>
-                <graph_item>
-                    <sortorder>3</sortorder>
-                    <drawtype>0</drawtype>
-                    <color>F63100</color>
-                    <yaxisside>0</yaxisside>
-                    <calc_fnc>7</calc_fnc>
-                    <type>0</type>
-                    <item>
-                        <host>Template MongoDB</host>
-                        <key>mongodb.memory.resident</key>
+                        <key>mongodb.used-cache</key>
                     </item>
                 </graph_item>
             </graph_items>
@@ -3594,6 +3700,74 @@ and {Template MongoDB:mongodb.priority.last()}=0</expression>
                     <item>
                         <host>Template MongoDB</host>
                         <key>mongodb.page.faults</key>
+                    </item>
+                </graph_item>
+            </graph_items>
+        </graph>
+        <graph>
+            <name>Wired Tiger Memory Usage</name>
+            <width>900</width>
+            <height>200</height>
+            <yaxismin>0.0000</yaxismin>
+            <yaxismax>100.0000</yaxismax>
+            <show_work_period>1</show_work_period>
+            <show_triggers>1</show_triggers>
+            <type>0</type>
+            <show_legend>1</show_legend>
+            <show_3d>0</show_3d>
+            <percent_left>0.0000</percent_left>
+            <percent_right>0.0000</percent_right>
+            <ymin_type_1>0</ymin_type_1>
+            <ymax_type_1>0</ymax_type_1>
+            <ymin_item_1>0</ymin_item_1>
+            <ymax_item_1>0</ymax_item_1>
+            <graph_items>
+                <graph_item>
+                    <sortorder>0</sortorder>
+                    <drawtype>0</drawtype>
+                    <color>1A7C11</color>
+                    <yaxisside>0</yaxisside>
+                    <calc_fnc>2</calc_fnc>
+                    <type>0</type>
+                    <item>
+                        <host>Template MongoDB</host>
+                        <key>mongodb.total-cache</key>
+                    </item>
+                </graph_item>
+                <graph_item>
+                    <sortorder>1</sortorder>
+                    <drawtype>0</drawtype>
+                    <color>F63100</color>
+                    <yaxisside>0</yaxisside>
+                    <calc_fnc>2</calc_fnc>
+                    <type>0</type>
+                    <item>
+                        <host>Template MongoDB</host>
+                        <key>mongodb.used-cache</key>
+                    </item>
+                </graph_item>
+                <graph_item>
+                    <sortorder>2</sortorder>
+                    <drawtype>0</drawtype>
+                    <color>2774A4</color>
+                    <yaxisside>0</yaxisside>
+                    <calc_fnc>2</calc_fnc>
+                    <type>0</type>
+                    <item>
+                        <host>Template MongoDB</host>
+                        <key>mongodb.dirty-cache</key>
+                    </item>
+                </graph_item>
+                <graph_item>
+                    <sortorder>3</sortorder>
+                    <drawtype>0</drawtype>
+                    <color>A54F10</color>
+                    <yaxisside>1</yaxisside>
+                    <calc_fnc>2</calc_fnc>
+                    <type>0</type>
+                    <item>
+                        <host>Template MongoDB</host>
+                        <key>mongodb.used-cache-p</key>
                     </item>
                 </graph_item>
             </graph_items>

--- a/Templates/Template_MongoDB.xml
+++ b/Templates/Template_MongoDB.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
     <version>3.2</version>
-    <date>2017-08-11T09:10:15Z</date>
+    <date>2017-08-11T10:47:57Z</date>
     <groups>
         <group>
             <name>Templates</name>
@@ -239,92 +239,6 @@
                     <logtimefmt/>
                 </item>
                 <item>
-                    <name>MongoDB::backgroundFlushing::flushes count</name>
-                    <type>2</type>
-                    <snmp_community/>
-                    <multiplier>0</multiplier>
-                    <snmp_oid/>
-                    <key>mongodb.backgroundFlushing.flushes</key>
-                    <delay>0</delay>
-                    <history>28</history>
-                    <trends>365</trends>
-                    <status>0</status>
-                    <value_type>3</value_type>
-                    <allowed_hosts/>
-                    <units/>
-                    <delta>2</delta>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <formula>1</formula>
-                    <delay_flex/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <data_type>0</data_type>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <description>The number of times the database has flushed all writes to disk. This value will grow as database runs for longer periods of time.</description>
-                    <inventory_link>0</inventory_link>
-                    <applications>
-                        <application>
-                            <name>MongoDB</name>
-                        </application>
-                    </applications>
-                    <valuemap/>
-                    <logtimefmt/>
-                </item>
-                <item>
-                    <name>MongoDB::backgroundFlushing::flush time</name>
-                    <type>2</type>
-                    <snmp_community/>
-                    <multiplier>1</multiplier>
-                    <snmp_oid/>
-                    <key>mongodb.backgroundFlushing.total_ms</key>
-                    <delay>0</delay>
-                    <history>28</history>
-                    <trends>365</trends>
-                    <status>0</status>
-                    <value_type>3</value_type>
-                    <allowed_hosts/>
-                    <units>s</units>
-                    <delta>2</delta>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <formula>0.001</formula>
-                    <delay_flex/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <data_type>0</data_type>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <description>The total number of milliseconds (ms) that the mongod processes have spent writing (i.e. flushing) data to disk. Because total_ms is an absolute value, consider the flushes and average_ms values to provide context.</description>
-                    <inventory_link>0</inventory_link>
-                    <applications>
-                        <application>
-                            <name>MongoDB</name>
-                        </application>
-                    </applications>
-                    <valuemap/>
-                    <logtimefmt/>
-                </item>
-                <item>
                     <name>MongoDB::connection::connection available</name>
                     <type>2</type>
                     <snmp_community/>
@@ -444,6 +358,49 @@
                     <privatekey/>
                     <port/>
                     <description>Count of all incoming connections created to the server. This number includes connections that have since closed.</description>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>MongoDB</name>
+                        </application>
+                    </applications>
+                    <valuemap/>
+                    <logtimefmt/>
+                </item>
+                <item>
+                    <name>MongoDB::FsyncLock</name>
+                    <type>2</type>
+                    <snmp_community/>
+                    <multiplier>0</multiplier>
+                    <snmp_oid/>
+                    <key>mongodb.fsync-locked</key>
+                    <delay>0</delay>
+                    <history>28</history>
+                    <trends>0</trends>
+                    <status>0</status>
+                    <value_type>4</value_type>
+                    <allowed_hosts/>
+                    <units/>
+                    <delta>0</delta>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <formula>1</formula>
+                    <delay_flex/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <data_type>0</data_type>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description>Tells the user if the MongoDB has fsync lock enabled, this prevents write operations and is turned on during some maintenance scripts.</description>
                     <inventory_link>0</inventory_link>
                     <applications>
                         <application>
@@ -755,19 +712,19 @@
                     <logtimefmt/>
                 </item>
                 <item>
-                    <name>MongoDB::heap size</name>
+                    <name>MongoDB::Hidden</name>
                     <type>2</type>
                     <snmp_community/>
                     <multiplier>0</multiplier>
                     <snmp_oid/>
-                    <key>mongodb.heap.size</key>
+                    <key>mongodb.hidden</key>
                     <delay>0</delay>
                     <history>28</history>
-                    <trends>365</trends>
+                    <trends>0</trends>
                     <status>0</status>
-                    <value_type>3</value_type>
+                    <value_type>4</value_type>
                     <allowed_hosts/>
-                    <units>B</units>
+                    <units/>
                     <delta>0</delta>
                     <snmpv3_contextname/>
                     <snmpv3_securityname/>
@@ -787,7 +744,7 @@
                     <publickey/>
                     <privatekey/>
                     <port/>
-                    <description/>
+                    <description>Tells the user if the MongoDB is hidden, this means the database can write operations from other members, but won't server reads</description>
                     <inventory_link>0</inventory_link>
                     <applications>
                         <application>
@@ -1481,7 +1438,7 @@ The amount of mapped memory, in megabytes (MB), including the memory used for jo
                     <publickey/>
                     <privatekey/>
                     <port/>
-                    <description/>
+                    <description>Describes the number of seconds that exist in the Oplog</description>
                     <inventory_link>0</inventory_link>
                     <applications>
                         <application>
@@ -1524,7 +1481,7 @@ The amount of mapped memory, in megabytes (MB), including the memory used for jo
                     <publickey/>
                     <privatekey/>
                     <port/>
-                    <description/>
+                    <description>Shows the number of seconds between the last operation in the oplog, and the the current time. This should be fairly accurate on a database that has continuous operations, but if the database doesn't do anything it will fall behind.</description>
                     <inventory_link>0</inventory_link>
                     <applications>
                         <application>
@@ -1568,6 +1525,49 @@ The amount of mapped memory, in megabytes (MB), including the memory used for jo
                     <privatekey/>
                     <port/>
                     <description/>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>MongoDB</name>
+                        </application>
+                    </applications>
+                    <valuemap/>
+                    <logtimefmt/>
+                </item>
+                <item>
+                    <name>MongoDB::Priority</name>
+                    <type>2</type>
+                    <snmp_community/>
+                    <multiplier>0</multiplier>
+                    <snmp_oid/>
+                    <key>mongodb.priority</key>
+                    <delay>0</delay>
+                    <history>28</history>
+                    <trends>365</trends>
+                    <status>0</status>
+                    <value_type>0</value_type>
+                    <allowed_hosts/>
+                    <units/>
+                    <delta>0</delta>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <formula>1</formula>
+                    <delay_flex/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <data_type>0</data_type>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description>The current priority of this database, 0 means it cannot be elected as master. This is used as part of the hiding process</description>
                     <inventory_link>0</inventory_link>
                     <applications>
                         <application>
@@ -2688,7 +2688,7 @@ Only present when using the mmapv1 storage engine.</description>
                             <dynamic>0</dynamic>
                             <sort_triggers>0</sort_triggers>
                             <resource>
-                                <name>MongoDB::memory and heap size</name>
+                                <name>MongoDB::memory</name>
                                 <host>Template MongoDB</host>
                             </resource>
                             <max_columns>3</max_columns>
@@ -2764,28 +2764,6 @@ Only present when using the mmapv1 storage engine.</description>
                             <resourcetype>0</resourcetype>
                             <width>500</width>
                             <height>100</height>
-                            <x>1</x>
-                            <y>2</y>
-                            <colspan>1</colspan>
-                            <rowspan>1</rowspan>
-                            <elements>0</elements>
-                            <valign>0</valign>
-                            <halign>0</halign>
-                            <style>0</style>
-                            <url/>
-                            <dynamic>0</dynamic>
-                            <sort_triggers>0</sort_triggers>
-                            <resource>
-                                <name>MongoDB::background flushing</name>
-                                <host>Template MongoDB</host>
-                            </resource>
-                            <max_columns>3</max_columns>
-                            <application/>
-                        </screen_item>
-                        <screen_item>
-                            <resourcetype>0</resourcetype>
-                            <width>500</width>
-                            <height>100</height>
                             <x>0</x>
                             <y>3</y>
                             <colspan>1</colspan>
@@ -2832,6 +2810,78 @@ Only present when using the mmapv1 storage engine.</description>
         </template>
     </templates>
     <triggers>
+        <trigger>
+            <expression>{Template MongoDB:mongodb.fsync-locked.str(&quot;True&quot;)}=1 &#13;
+and {Template MongoDB:mongodb.hidden.str(&quot;True&quot;)}=1 &#13;
+and {Template MongoDB:mongodb.priority.last()}=0</expression>
+            <recovery_mode>0</recovery_mode>
+            <recovery_expression/>
+            <name>Locked, hidden and priority 0 on {HOST.NAME}</name>
+            <correlation_mode>0</correlation_mode>
+            <correlation_tag/>
+            <url/>
+            <status>0</status>
+            <priority>2</priority>
+            <description>The database is locked, hidden and priority set to 0</description>
+            <type>0</type>
+            <manual_close>0</manual_close>
+            <dependencies/>
+            <tags/>
+        </trigger>
+        <trigger>
+            <expression>{Template MongoDB:mongodb.fsync-locked.str(&quot;True&quot;)}=1 &#13;
+and {Template MongoDB:mongodb.hidden.str(&quot;True&quot;)}=1 &#13;
+and {Template MongoDB:mongodb.priority.last()}=1</expression>
+            <recovery_mode>0</recovery_mode>
+            <recovery_expression/>
+            <name>Locked, hidden and priority 1 on {HOST.NAME}</name>
+            <correlation_mode>0</correlation_mode>
+            <correlation_tag/>
+            <url/>
+            <status>0</status>
+            <priority>4</priority>
+            <description>The database is locked, hidden and priority set to 1</description>
+            <type>0</type>
+            <manual_close>0</manual_close>
+            <dependencies/>
+            <tags/>
+        </trigger>
+        <trigger>
+            <expression>{Template MongoDB:mongodb.fsync-locked.str(&quot;True&quot;)}=1 &#13;
+and {Template MongoDB:mongodb.hidden.str(&quot;False&quot;)}=1 &#13;
+and {Template MongoDB:mongodb.priority.last()}=0</expression>
+            <recovery_mode>0</recovery_mode>
+            <recovery_expression/>
+            <name>Locked, not hidden and priority 0 on {HOST.NAME}</name>
+            <correlation_mode>0</correlation_mode>
+            <correlation_tag/>
+            <url/>
+            <status>0</status>
+            <priority>4</priority>
+            <description>The database is locked, hidden and priority set to 0</description>
+            <type>0</type>
+            <manual_close>0</manual_close>
+            <dependencies/>
+            <tags/>
+        </trigger>
+        <trigger>
+            <expression>{Template MongoDB:mongodb.fsync-locked.str(&quot;True&quot;)}=1 &#13;
+and {Template MongoDB:mongodb.hidden.str(&quot;False&quot;)}=1 &#13;
+and {Template MongoDB:mongodb.priority.last()}=1</expression>
+            <recovery_mode>0</recovery_mode>
+            <recovery_expression/>
+            <name>Locked, not hidden and priority 1 on {HOST.NAME}</name>
+            <correlation_mode>0</correlation_mode>
+            <correlation_tag/>
+            <url/>
+            <status>0</status>
+            <priority>4</priority>
+            <description>The database is locked, not hidden and priority set to 1</description>
+            <type>0</type>
+            <manual_close>0</manual_close>
+            <dependencies/>
+            <tags/>
+        </trigger>
         <trigger>
             <expression>{Template MongoDB:mongodb.oplog.last()}&lt;259200</expression>
             <recovery_mode>1</recovery_mode>
@@ -2923,6 +2973,60 @@ Only present when using the mmapv1 storage engine.</description>
             <status>0</status>
             <priority>3</priority>
             <description/>
+            <type>0</type>
+            <manual_close>0</manual_close>
+            <dependencies/>
+            <tags/>
+        </trigger>
+        <trigger>
+            <expression>{Template MongoDB:mongodb.fsync-locked.str(&quot;False&quot;)}=1 &#13;
+and {Template MongoDB:mongodb.hidden.str(&quot;True&quot;)}=1 &#13;
+and {Template MongoDB:mongodb.priority.last()}=0</expression>
+            <recovery_mode>0</recovery_mode>
+            <recovery_expression/>
+            <name>Not locked, but is hidden and priority 0 on {HOST.NAME}</name>
+            <correlation_mode>0</correlation_mode>
+            <correlation_tag/>
+            <url/>
+            <status>0</status>
+            <priority>2</priority>
+            <description>The database is not locked, but is hidden and priority set to 0</description>
+            <type>0</type>
+            <manual_close>0</manual_close>
+            <dependencies/>
+            <tags/>
+        </trigger>
+        <trigger>
+            <expression>{Template MongoDB:mongodb.fsync-locked.str(&quot;False&quot;)}=1 &#13;
+and {Template MongoDB:mongodb.hidden.str(&quot;True&quot;)}=1 &#13;
+and {Template MongoDB:mongodb.priority.last()}=1</expression>
+            <recovery_mode>0</recovery_mode>
+            <recovery_expression/>
+            <name>Not locked, is hidden and priority 1 on {HOST.NAME}</name>
+            <correlation_mode>0</correlation_mode>
+            <correlation_tag/>
+            <url/>
+            <status>0</status>
+            <priority>4</priority>
+            <description>The database is not locked, is hidden and priority set to 1</description>
+            <type>0</type>
+            <manual_close>0</manual_close>
+            <dependencies/>
+            <tags/>
+        </trigger>
+        <trigger>
+            <expression>{Template MongoDB:mongodb.fsync-locked.str(&quot;False&quot;)}=1 &#13;
+and {Template MongoDB:mongodb.hidden.str(&quot;False&quot;)}=1 &#13;
+and {Template MongoDB:mongodb.priority.last()}=0</expression>
+            <recovery_mode>0</recovery_mode>
+            <recovery_expression/>
+            <name>Not locked or hidden, but priority 0 on {HOST.NAME}</name>
+            <correlation_mode>0</correlation_mode>
+            <correlation_tag/>
+            <url/>
+            <status>0</status>
+            <priority>2</priority>
+            <description>The database is not locked or hidden, but priority set to 0</description>
             <type>0</type>
             <manual_close>0</manual_close>
             <dependencies/>
@@ -3022,50 +3126,6 @@ Only present when using the mmapv1 storage engine.</description>
                     <item>
                         <host>Template MongoDB</host>
                         <key>mongodb.asserts.warning</key>
-                    </item>
-                </graph_item>
-            </graph_items>
-        </graph>
-        <graph>
-            <name>MongoDB::background flushing</name>
-            <width>900</width>
-            <height>200</height>
-            <yaxismin>0.0000</yaxismin>
-            <yaxismax>100.0000</yaxismax>
-            <show_work_period>1</show_work_period>
-            <show_triggers>1</show_triggers>
-            <type>0</type>
-            <show_legend>1</show_legend>
-            <show_3d>0</show_3d>
-            <percent_left>0.0000</percent_left>
-            <percent_right>0.0000</percent_right>
-            <ymin_type_1>0</ymin_type_1>
-            <ymax_type_1>0</ymax_type_1>
-            <ymin_item_1>0</ymin_item_1>
-            <ymax_item_1>0</ymax_item_1>
-            <graph_items>
-                <graph_item>
-                    <sortorder>0</sortorder>
-                    <drawtype>0</drawtype>
-                    <color>1A7C11</color>
-                    <yaxisside>0</yaxisside>
-                    <calc_fnc>7</calc_fnc>
-                    <type>0</type>
-                    <item>
-                        <host>Template MongoDB</host>
-                        <key>mongodb.backgroundFlushing.flushes</key>
-                    </item>
-                </graph_item>
-                <graph_item>
-                    <sortorder>1</sortorder>
-                    <drawtype>0</drawtype>
-                    <color>F63100</color>
-                    <yaxisside>1</yaxisside>
-                    <calc_fnc>7</calc_fnc>
-                    <type>0</type>
-                    <item>
-                        <host>Template MongoDB</host>
-                        <key>mongodb.backgroundFlushing.total_ms</key>
                     </item>
                 </graph_item>
             </graph_items>
@@ -3227,7 +3287,7 @@ Only present when using the mmapv1 storage engine.</description>
             </graph_items>
         </graph>
         <graph>
-            <name>MongoDB::memory and heap size</name>
+            <name>MongoDB::memory</name>
             <width>900</width>
             <height>200</height>
             <yaxismin>0.0000</yaxismin>
@@ -3290,18 +3350,6 @@ Only present when using the mmapv1 storage engine.</description>
                     <item>
                         <host>Template MongoDB</host>
                         <key>mongodb.memory.resident</key>
-                    </item>
-                </graph_item>
-                <graph_item>
-                    <sortorder>4</sortorder>
-                    <drawtype>0</drawtype>
-                    <color>A54F10</color>
-                    <yaxisside>0</yaxisside>
-                    <calc_fnc>7</calc_fnc>
-                    <type>0</type>
-                    <item>
-                        <host>Template MongoDB</host>
-                        <key>mongodb.heap.size</key>
                     </item>
                 </graph_item>
             </graph_items>

--- a/bin/zabbix-mongodb.py
+++ b/bin/zabbix-mongodb.py
@@ -6,6 +6,8 @@
 # Requires: MongoClient in python
 
 from pymongo import MongoClient
+from calendar import timegm
+from time import gmtime
 import json
 
 class MongoDB(object):
@@ -75,6 +77,36 @@ class MongoDB(object):
                 DBList.append(dict)
         return {"data":DBList}
 
+    def getOplog(self):
+        error = False
+
+        db = MongoClient(self.mongo_host, self.mongo_port)
+
+        if self.mongo_user and self.mongo_password:
+            db.authenticate(self.mongo_user, self.mongo_password)
+
+        dbl = db.local
+        coll = dbl['oplog.rs']
+
+        op_first = (coll.find().sort('$natural', 1).limit(1))
+
+        while op_first.alive:
+            op_fst = (op_first.next())['ts'].time
+
+        op_last = (coll.find().sort('$natural', -1).limit(1))
+
+        while op_last.alive:
+            op_last_st = op_last[0]['ts']
+            op_lst = (op_last.next())['ts'].time
+
+        #status = round(((((float(op_lst - op_fst)) / 60) / 60) / 24), 1)
+        status = round(float(op_lst - op_fst), 1)
+        self.addMetrics('mongodb.oplog', status)
+
+        currentTime = timegm(gmtime())
+        oplog = int(((str(op_last_st).split('('))[1].split(','))[0])
+        self.addMetrics('mongodb.oplog-sync', (currentTime - oplog))
+
     # Get Server Status
     def getServerStatusMetrics(self):
         if self.__conn is None:
@@ -83,6 +115,7 @@ class MongoDB(object):
         if self.mongo_user and self.mongo_password:
             db.authenticate(self.mongo_user, self.mongo_password)
         ss = db.command('serverStatus')
+
         #print ss
 
         # db info
@@ -94,10 +127,6 @@ class MongoDB(object):
         # asserts
         for k, v in ss['asserts'].items():
             self.addMetrics('mongodb.asserts.' + k, v)
-
-        # background flushing
-        self.addMetrics('mongodb.backgroundFlushing.flushes', ss['backgroundFlushing']['flushes'])
-        self.addMetrics('mongodb.backgroundFlushing.total_ms', ss['backgroundFlushing']['total_ms'])
 
         # operations
         for k, v in ss['opcounters'].items():
@@ -116,7 +145,6 @@ class MongoDB(object):
             self.addMetrics('mongodb.network.' + k, v)
 
         # extra info
-        self.addMetrics('mongodb.heap.size', ss['extra_info']['heap_usage_bytes'])
         self.addMetrics('mongodb.page.faults', ss['extra_info']['page_faults'])
 
         # global lock
@@ -152,6 +180,7 @@ if __name__ == '__main__':
     MongoDB.getDBNames()
     MongoDB_LLD = str(json.dumps(MongoDB.getMongoDBLLD()))
     print '- mongodb.discovery ' + MongoDB_LLD
+    MongoDB.getOplog()
     MongoDB.getServerStatusMetrics()
     MongoDB.getDBStatsMetrics()
     MongoDB.printMetrics()

--- a/bin/zabbix-mongodb.py
+++ b/bin/zabbix-mongodb.py
@@ -114,13 +114,13 @@ class MongoDB(object):
 
         host_name = socket.gethostname()
 
-        fsync_locked = db.is_locked
+        fsync_locked = int(db.is_locked)
 
         config = db.admin.command("replSetGetConfig", 1)
         for i in range(0, len(config['config']['members'])):
             if host_name in config['config']['members'][i]['host']:
                 priority = config['config']['members'][i]['priority']
-                hidden = config['config']['members'][i]['hidden']
+                hidden = int(config['config']['members'][i]['hidden'])
 
         self.addMetrics('mongodb.fsync-locked', fsync_locked)
         self.addMetrics('mongodb.priority', priority)

--- a/bin/zabbix-mongodb.py
+++ b/bin/zabbix-mongodb.py
@@ -167,6 +167,11 @@ class MongoDB(object):
         # extra info
         self.addMetrics('mongodb.page.faults', ss['extra_info']['page_faults'])
 
+        #wired tiger
+        self.addMetrics('mongodb.used-cache', ss['wiredTiger']['cache']["bytes currently in the cache"])
+        self.addMetrics('mongodb.total-cache', ss['wiredTiger']['cache']["maximum bytes configured"])
+        self.addMetrics('mongodb.dirty-cache', ss['wiredTiger']['cache']["tracked dirty bytes in the cache"])
+
         # global lock
         lockTotalTime = ss['globalLock']['totalTime']
         self.addMetrics('mongodb.globalLock.totalTime', lockTotalTime)


### PR DESCRIPTION
I've removed the background flushing and heap size metrics which have been deprecated in mongo 3.4 as mentioned in issue #1 

Further to this I have added a couple of checks which we consider essential, these are checks which look at the oplog sync and oplog lag. I was trying to make these work so they followed your code style/conventions, but I was unable to get the cursor to work (I always hit a StopIteration, even when I checked that the cursor was alive as per the docs: http://api.mongodb.com/python/current/api/pymongo/cursor.html) so I ended up doing this in the only way I could get it to work. Maybe you can improve my code to make this work and keep it in the same style your original code worked.