### PR TITLE
Not all memory fields exist on all versions

### DIFF
--- a/bin/zabbix-mongodb.py
+++ b/bin/zabbix-mongodb.py
@@ -182,7 +182,8 @@ class MongoDB(object):
 
         # memory
         for k in ['resident', 'virtual', 'mapped', 'mappedWithJournal']:
-            self.add_metrics('mongodb.memory.' + k, ss['mem'][k])
+            if k in ss['mem'].keys():
+                self.add_metrics('mongodb.memory.' + k, ss['mem'][k])
 
         # connections
         for k, v in ss['connections'].items():


### PR DESCRIPTION
Only record memory metrics that we get back from ServerStatus. 

e.g. mapped and mappedWithJournal no longer exist in 4.2